### PR TITLE
Conform to Kubernetes repo requirements

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,25 @@
+# Contributing Guidelines
+
+Welcome to Kubernetes. We are excited about the prospect of you joining our [community](https://github.com/kubernetes/community)! The Kubernetes community abides by the CNCF [code of conduct](code-of-conduct.md). Here is an excerpt:
+
+_As contributors and maintainers of this project, and in the interest of fostering an open and welcoming community, we pledge to respect all people who contribute through reporting issues, posting feature requests, updating documentation, submitting pull requests or patches, and other activities._
+
+## Getting Started
+
+We have full documentation on how to get started contributing here:
+
+<!---
+If your repo has certain guidelines for contribution, put them here ahead of the general k8s resources
+-->
+
+- [Contributor License Agreement](https://git.k8s.io/community/CLA.md) Kubernetes projects require that you sign a Contributor License Agreement (CLA) before we can accept your pull requests
+- [Kubernetes Contributor Guide](http://git.k8s.io/community/contributors/guide) - Main contributor documentation, or you can just jump directly to the [contributing section](http://git.k8s.io/community/contributors/guide#contributing)
+- [Contributor Cheat Sheet](https://git.k8s.io/community/contributors/guide/contributor-cheatsheet.md) - Common resources for existing developers
+
+## Mentorship
+
+- [Mentoring Initiatives](https://git.k8s.io/community/mentoring) - We have a diverse set of mentorship programs available that are always looking for volunteers!
+
+## Contact Information
+
+- [Slack channel](https://kubernetes.slack.com/messages/cluster-api-azure) - [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-cluster-lifecycle)

--- a/LICENSE
+++ b/LICENSE
@@ -178,7 +178,7 @@
    APPENDIX: How to apply the Apache License to your work.
 
       To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "[]"
+      boilerplate notice, with the fields enclosed by brackets "{}"
       replaced with your own identifying information. (Don't include
       the brackets!)  The text should be enclosed in the appropriate
       comment syntax for the file format. We also recommend that a
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright {yyyy} {name of copyright owner}
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,15 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+
+approvers:
+  - sig-cluster-lifecycle-leads
+  - sig-azure-leads
+  - cluster-api-admins
+  - cluster-api-maintainers
+  - cluster-api-azure-maintainers
+
+reviewers:
+  - cluster-api-maintainers
+  - cluster-api-azure-maintainers
+
+labels:
+  - sig/azure

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,0 +1,41 @@
+# See the OWNERS_ALIASES docs: https://git.k8s.io/community/contributors/guide/owners.md#owners_aliases
+
+aliases:
+  sig-cluster-lifecycle-leads:
+    - lukemarsden
+    - luxas
+    - roberthbailey
+    - timothysc
+  cluster-api-admins:
+    - justinsb
+    - krousey
+    - luxas
+    - roberthbailey
+    - kris-nova
+  cluster-api-maintainers:
+    - jessicaochen
+    - k4leung4
+    - karan
+    - kris-nova
+    - krousey
+    - medinatiger
+    - mkjelland
+    - roberthbailey
+    - rsdcastro
+    - spew
+  sig-azure-leads:
+    - dstrebel
+    - feiskyer
+    - justaugustus
+    - khenidak
+  cluster-api-azure-maintainers:
+    - andyzhangx
+    - brendandburns
+    - feiskyer
+    - justaugustus
+    - karataliu
+    - khenidak
+    - marwanad
+    - soggiest
+    - tariq1890
+    - vannrt

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,9 @@
+# Release Process
+
+The Cluster API for Azure is released on an as-needed basis. The process is as follows:
+
+1. An issue is proposing a new release with a changelog since the last release
+1. All [OWNERS](OWNERS) must LGTM this release
+1. An OWNER runs `git tag -s $VERSION` and inserts the changelog and pushes the tag with `git push $VERSION`
+1. The release issue is closed
+1. An announcement email is sent to `kubernetes-dev@googlegroups.com` with the subject `[ANNOUNCE] cluster-api-provider-azure $VERSION is released`

--- a/SECURITY_CONTACTS
+++ b/SECURITY_CONTACTS
@@ -1,0 +1,16 @@
+# Defined below are the security contacts for this repo.
+#
+# They are the contact point for the Product Security Team to reach out
+# to for triaging and handling of incoming issues.
+#
+# The below names agree to abide by the
+# [Embargo Policy](https://github.com/kubernetes/sig-release/blob/master/security-release-process-documentation/security-release-process.md#embargo-policy)
+# and will be removed and replaced if they violate that agreement.
+#
+# DO NOT REPORT SECURITY VULNERABILITIES DIRECTLY TO THESE NAMES, FOLLOW THE
+# INSTRUCTIONS AT https://kubernetes.io/security/
+
+justaugustus
+soggiest
+tariq1890
+vannrt

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -1,0 +1,3 @@
+# Kubernetes Community Code of Conduct
+
+Please refer to our [Kubernetes Community Code of Conduct](https://git.k8s.io/community/code-of-conduct.md)


### PR DESCRIPTION
Kubernetes repo requirements can be reviewed [here](https://github.com/kubernetes/community/blob/master/github-management/kubernetes-repositories.md)
* Add CONTRIBUTING.md
* Add OWNERS
* Add OWNERS_ALIASES
* Add RELEASE.md
* Add SECURITY_CONTACTS
* Add code-of-conduct.md

Signed-off-by: Stephen Augustus <foo@agst.us>